### PR TITLE
Add 406 as a valid response code

### DIFF
--- a/src/Postmark/Transport.php
+++ b/src/Postmark/Transport.php
@@ -95,8 +95,9 @@ class Transport implements Swift_Transport {
 		]);
 
 		$success = $response->getStatusCode() === 200;
+		$received = $success || $response->getStatusCode() === 406; // 406: Inactive recipient
 
-		if ($responseEvent = $this->_eventDispatcher->createResponseEvent($this, $response->getBody()->getContents(), $success)) {
+		if ($responseEvent = $this->_eventDispatcher->createResponseEvent($this, $response->getBody()->getContents(), $received)) {
 			$this->_eventDispatcher->dispatchEvent($responseEvent, 'responseReceived');
 		}
 

--- a/tests/TransportTest.php
+++ b/tests/TransportTest.php
@@ -160,6 +160,17 @@ class MailPostmarkTransportTest extends TestCase {
         $this->expectException(\Swift_TransportException::class);
         $transport->send($message);
     }
+
+    public function testResponseDoesNotFailOn406()
+    {
+        $message = new Swift_Message();
+        $message->addTo('you@example.com', 'A. Friend');
+
+        $transport = new PostmarkTransportStub([new Response(406)]);
+        $transport->registerPlugin(new \Postmark\ThrowExceptionOnFailurePlugin());
+
+        $this->assertSame(0, $transport->send($message));
+    }
 }
 
 


### PR DESCRIPTION
When the response code is 406, the api returned a valid response.

More info on error codes:
https://postmarkapp.com/developer/api/overview#error-codes
> 406 — Inactive recipient You tried to send email to a recipient
> that has been marked as inactive. Inactive recipients have either
> generated a hard bounce or a spam complaint. In this case, only
> hard bounce recipients can be reactivated by searching for them on
> your server’s Activity page and clicking the “Reactivate” button.