### PR TITLE
Use correct status & error code

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ $transport = new \Postmark\Transport('<SERVER_TOKEN>');
 $transport->registerPlugin(new \Postmark\ThrowExceptionOnFailurePlugin());
 
 $message = new Swift_Message('Hello from Postmark!');
-$mailer->send($message); // Exception is throw when response !== 200
+$mailer->send($message); // Exception is throw when response is not 200
 
 ?>
 ```

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,8 @@
     "name": "wildbit/swiftmailer-postmark",
     "description": "A Swiftmailer Transport for Postmark.",
     "require": {
+        "php" : "^7.1",
+        "ext-json": "*",
         "swiftmailer/swiftmailer": "^6.0.0",
         "guzzlehttp/guzzle": "^6.0.0"
     },

--- a/src/Postmark/Transport.php
+++ b/src/Postmark/Transport.php
@@ -10,7 +10,23 @@ use Swift_Transport;
 
 class Transport implements Swift_Transport {
 
-	protected $version = "Unknown PHP version";
+    /**
+     * 406 — Inactive recipient You tried to send email to a recipient that has
+     * been marked as inactive. Inactive recipients have either generated a
+     * hard bounce or a spam complaint. In this case, only hard bounce recipients
+     * can be reactivated by searching for them on your server’s Activity page and
+     * clicking the “Reactivate” button.
+     */
+    private const ERROR_CODE_INACTIVE_RECIPIENT = 406;
+
+    /**
+     * Whenever the Postmark server detects an input error it will return an
+     * HTTP 422 status code along with a JSON object containing error details
+     */
+    private const STATUS_CODE_CLIENT_ERROR = 422;
+    private const STATUS_CODE_OK = 200;
+
+    protected $version = "Unknown PHP version";
 	protected $os = "Unknown OS";
 
 	/**
@@ -94,10 +110,14 @@ class Transport implements Swift_Transport {
 			'http_errors' => false,
 		]);
 
-		$success = $response->getStatusCode() === 200;
-		$received = $success || $response->getStatusCode() === 406; // 406: Inactive recipient
+		$success = $response->getStatusCode() === self::STATUS_CODE_OK;
+		$clientError = $response->getStatusCode() === self::STATUS_CODE_CLIENT_ERROR;
 
-		if ($responseEvent = $this->_eventDispatcher->createResponseEvent($this, $response->getBody()->getContents(), $received)) {
+        $responseBody = json_decode($response->getBody()->getContents(), true);
+        $errorCode = (int) $responseBody['ErrorCode'] ?? 0;
+        $validResponse = $success || ($clientError && $errorCode === self::ERROR_CODE_INACTIVE_RECIPIENT);
+
+		if ($responseEvent = $this->_eventDispatcher->createResponseEvent($this, $response->getBody()->getContents(), $validResponse)) {
 			$this->_eventDispatcher->dispatchEvent($responseEvent, 'responseReceived');
 		}
 

--- a/tests/TransportTest.php
+++ b/tests/TransportTest.php
@@ -154,7 +154,7 @@ class MailPostmarkTransportTest extends TestCase {
     {
         $message = new Swift_Message();
 
-        $transport = new PostmarkTransportStub([new Response(401)]);
+        $transport = new PostmarkTransportStub([new Response(422, [], '{"ErrorCode": 10, "Message": "wrong token"}')]);
         $transport->registerPlugin(new \Postmark\ThrowExceptionOnFailurePlugin());
 
         $this->expectException(\Swift_TransportException::class);
@@ -166,7 +166,7 @@ class MailPostmarkTransportTest extends TestCase {
         $message = new Swift_Message();
         $message->addTo('you@example.com', 'A. Friend');
 
-        $transport = new PostmarkTransportStub([new Response(406)]);
+        $transport = new PostmarkTransportStub([new Response(422, [], '{"ErrorCode": 406, "Message": "message"}')]);
         $transport->registerPlugin(new \Postmark\ThrowExceptionOnFailurePlugin());
 
         $this->assertSame(0, $transport->send($message));


### PR DESCRIPTION
The previous attempt to catch 406 error codes was wrong. It checked for the status code 406, but should have checked for the ErrorCode 406 (on response code 422)